### PR TITLE
Update docker run args in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ docker build --tag robinhood-on-rails .
 
 Then you can run the server:
 ```shell
-$ docker run --rm -dt -p 3000:3000 robinhood-on-rails
+$ docker run -dt -p 3000:3000 robinhood-on-rails
 ```
 
 This will run the server on your host-machine's port 3000.


### PR DESCRIPTION
When running the previous docker run command I encountered the following error:

`Conflicting options: --rm and -d`

Removing the `--rm` resolved the issue for me. 

Tested on Mac OS.