### PR TITLE
Fixed Dockerfile to use your local dev repo directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
 FROM ruby:2.2.2
 
-WORKDIR $HOME/
+ADD . $HOME/robinhood-on-rails
+WORKDIR $HOME/robinhood-on-rails
 
-RUN git clone https://github.com/bcwik9/robinhood-on-rails.git
-RUN cd robinhood-on-rails
-
-
-COPY Gemfile* $HOME/
 RUN bundle install
 
-ADD . $HOME
 RUN bundle exec rake db:create db:migrate
 
 #CMD ["bundle", "exec", "rails", "server"]


### PR DESCRIPTION
The (previous) Dockerfile cloned from github and then copied the local repo into /
this commit changes that to just ADD the local dev repo into /robinhood-on-rails
and change WORKDIR to that location to make for a cleaner docker deploy (since 'RUN cd' doesn't really work in a Dockerfile)
