### PR TITLE
Improve performance by checking db  before fetching from Robinhood

### DIFF
--- a/app/controllers/robinhood_controller.rb
+++ b/app/controllers/robinhood_controller.rb
@@ -409,7 +409,7 @@ class RobinhoodController < ApplicationController
   def orders
     get_orders
     @orders.each do |order|
-      order["instrument"] = robinhood_get order["instrument"]
+      order["instrument"] = find_or_create_instrument order["instrument"]
       order["filled_quantity"] = order["executions"].map{|e| e["quantity"].to_i}.sum.to_s
     end
   end


### PR DESCRIPTION
In Orders tab, instead of fetching all instrumentation from Robinhood API, which causes delays, fetch from database first.